### PR TITLE
feat: guard tempo devtools behind env flag

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,8 +5,11 @@ import "./index.css";
 import { BrowserRouter } from "react-router-dom";
 import { logger } from "@/lib/logger";
 
-import { TempoDevtools } from "tempo-devtools";
-TempoDevtools.init();
+if (import.meta.env.DEV) {
+  import("tempo-devtools").then(({ TempoDevtools }) => {
+    TempoDevtools.init();
+  });
+}
 
 // Force cache busting in development
 if (import.meta.env.DEV) {


### PR DESCRIPTION
## Summary
- load tempo-devtools only when `import.meta.env.DEV`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`
- `rg "tempo-devtools" -n dist || true`


------
https://chatgpt.com/codex/tasks/task_e_689ac269f5e8832b9efe9c266d966d61